### PR TITLE
Version of the separate Dockerfiles updated with Makefile

### DIFF
--- a/dockerfiles/Makefile
+++ b/dockerfiles/Makefile
@@ -1,0 +1,40 @@
+-include setenv.sh
+
+.PHONY: all create-env build
+
+create-env: ## Force write/overwrite the .env file
+	@echo "BASE_IMAGE=${BASE_IMAGE}\n" \
+    "PG_VERSION=$(PG_VERSION)\n" \
+	"INSTALL_REPO=$(INSTALL_REPO)\n" \
+    "CONFIG_DIR=${CONFIG_DIR}\n" \
+    "DOCKER_BIN=${DOCKER_BIN}\n" \
+    "SERVER_PORT=${SERVER_PORT}\n" \
+    "PG_NAME=$(PG_NAME)\n" \
+    "DACHS_NAME=$(DACHS_NAME)\n" \
+    "GAVO_DATA=$(GAVO_DATA)"> .env
+
+build: create-env ## Build the Docker images using central environment variables
+	@echo "Building images with PG_VERSION=$(PG_VERSION)..."
+	docker compose build --no-cache=true \
+		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
+		--build-arg PG_VERSION=$(PG_VERSION) \
+		--build-arg INSTALL_REPO=$(INSTALL_REPO) \
+        --build-arg CONFIG_DIR=$(CONFIG_DIR) \
+        --build-arg DOCKER_BIN=$(DOCKER_BIN) \
+        --build-arg GAVO_DATA=$(GAVO_DATA)
+
+up: create-env ## Start the containers in the background
+	docker compose up -d
+
+down: create-env ## Stop and remove containers
+	docker compose down
+
+update_config: ## Update gavo.rc and metadata (uses CONFIG_DIR)
+	@echo "Updating DaCHS configuration in container from $(CONFIG_DIR)..."
+	docker cp "${CONFIG_DIR}/gavo.rc" "${DACHS_NAME}:/etc/gavo.rc"
+	##docker cp "${CONFIG_DIR}/defaultmeta.txt" "${DACHS_NAME}:/var/gavo/etc/"
+	##docker cp "${CONFIG_DIR}/userconfig.rd" "${DACHS_NAME}:/var/gavo/etc/"
+	docker exec -it ${DACHS_NAME} sh -c "dachs pub //services"
+
+restart: ## Restart the DaCHS server
+	docker exec $(DACHS_NAME) dachs serve restart

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -21,13 +21,12 @@ In default _compose_ file (`docker-compose.yml`) there is `dachs` (and `awstats`
 In _compose_ `docker-compose.full.yml`, you'll see `dachs-server` and `dachs-postgres`
 (and `awstats`) composing individual services.
 
-
-## Build details
 Have a look in the [README file in `dachs/`](dachs/README.md) for details on
 building the individual containers.
 
+## Building dachs in single image
 
-## Run compose
+### Run compose
 > If you don't have yet, install [`docker-compose`](https://docs.docker.com/compose/install/).
 
 To run (and build if not yet) the containers:
@@ -40,15 +39,10 @@ This will use `docker-compose.yml` to build and run containers.
 The default Dachs container built is the _latest_ `dachs` container
 -- using GAVO's apt repository.
 
-To run dachs/postgres server containers individually, `docker-compose.full.yml`
-is a sample of such setup:
-
-```bash
-$ docker-compose -f docker-compose.full.yml
-```
+To run dachs/postgres server containers individually, see description below.
 
 
-## Build compose
+### Build compose
 
 To (re)build the containers defined in a compose file:
 
@@ -56,8 +50,7 @@ To (re)build the containers defined in a compose file:
 $ docker-compose build
 ```
 
-
-## Environment variables
+### Environment variables
 The variables used in the _compose_ files can be defined in an "env" file
 to fix some settings on the containers building and running.
 
@@ -78,3 +71,50 @@ Example run:
 ```bash
 $ docker-compose --env-file env.rc up
 ```
+
+## Composed setup with separate server and database
+
+### Container Specifications
+
+The VO server is split into two functional components:
+
+1.  Database Container (Dockerfile.dachs_postgres)
+2.  Application Container (Dockerfile.dachs_server): Mounts `gavo.rc` to `/etc/gavo.rc` and expects the database to be reachable on startup
+
+Use the docker-compose.full.yml (renamed to docker-compose.yml), variable setting in setenv.sh and make commands in the root directory to build the images. 
+
+As the images use the Debian package system for installation, make sure that the according postgres version is available through apt.
+
+### Building the containers
+
+To build the containers, 
+
+#### 1. Set the relevant environment variables in `setenv.sh` and run
+
+```bash
+source setenv.sh
+```
+
+In this file, the container names, endpoint for the dachs server and paths to supplementary files are defined. The files at `/bin_composed` are obligatory for running the containers, additional settings can be added by specifying a $CONFIGS folder holding e.g. files like the defaultmeta.txt.
+
+#### 2. Building the containers
+
+The included `Makefile` provides a standardized interface for building and running the stack.
+
+* **Build the images**:
+    ```bash
+    make build
+    ```
+    *This executes `docker compose build` using the variables defined in your environment.*
+
+* **Start the services**:
+    ```bash
+    make up
+    ```
+    *Starts the PostgreSQL and DaCHS containers in the background.*
+
+* **Stop the services**:
+    ```bash
+    make down
+    ```
+

--- a/dockerfiles/dachs/Dockerfile.dachs_postgres
+++ b/dockerfiles/dachs/Dockerfile.dachs_postgres
@@ -1,95 +1,77 @@
+# 1. Declare ARGs (Values come from --build-arg or docker-compose)
 ARG BASE_IMAGE="debian:stable"
-
-# BUILD argument for extra repositories (besides debian/stable) to install dachs.
-# Options are:
-# - "gavo/beta" (gavo/release + gavo/beta)
-# - "backports" (debian/backports)
-# - "main" (debian/main)
-# * Default is "main"
+ARG PG_VERSION="17"
 ARG INSTALL_REPO="main"
-
-# PostgreSQL version to install
-# * Default is "15"
-ARG PG_VERSION="15"
+ARG DOCKER_BIN="bin"
 
 FROM $BASE_IMAGE
 
-LABEL Description=DaCHS\ is\ a\ publishing\ infrastructure\ for\ the\ Virtual\ Observatory. \
+# Re-declare for use in RUN commands
+ARG PG_VERSION
+ARG INSTALL_REPO
+ARG DOCKER_BIN
+
+LABEL Description=DaCHS\ Postgres\ for\ compose.\ DaCHS\ is\ a\ publishing\ infrastructure\ for\ the\ Virtual\ Observatory. \
     Reference=http://arxiv.org/abs/1408.5733
 
-# Everyday tools
+# 1. Install System Tools
 RUN DEBIAN_FRONTEND='noninteractive' \
     && apt-get update \
     && apt-get install -y \
-    curl \
-    git \
-    gnupg2 \
-    locales \
-    procps \
-    sudo \
-    vim \
-    wget \
+    curl git gnupg2 locales procps sudo vim wget \
     && apt-get clean
 
-
+# 2. Setup GAVO Repository
 ENV _APT_SOURCES="/etc/apt/sources.list.d/gavo.list"
-COPY etc/apt_sources.list "$_APT_SOURCES"
+COPY ${DOCKER_BIN}/apt_sources.list "$_APT_SOURCES"
 
-# Some fixes on the environment
-# ---
-# This is the brute-force solution for Debian;
-# I am having problems in set locales non-interactively,
-# and since I really need the "C/UTF8" for postgres, will just set it for all.
-ENV LC_ALL=C.UTF-8
-RUN echo LC_ALL="$LC_ALL" > /etc/default/locale
-
-RUN sed -i 's/exit 101/exit 0/' /usr/sbin/policy-rc.d
-# ---
-
-# Setup GAVO key, then repositories according to INSTALL_REPO
-# RUN wget -qO - http://docs.g-vo.org/archive-key.asc | apt-key add -
-RUN curl https://vo.ari.uni-heidelberg.de/debian/gavo-archive-keyring.asc \
+RUN curl -s https://vo.ari.uni-heidelberg.de/debian/gavo-archive-keyring.asc \
     | tee /etc/apt/trusted.gpg.d/gavo-archive.keyring.asc
 
-# If installing any version other than "main", backports is in there:
 RUN [ "$INSTALL_REPO" != "main" ] \
     && sed -i '/deb.*backports/s/^#//' $_APT_SOURCES \
-    || echo "NOT using debian/backports repo"
+    || echo "Using main repo only"
 
-# If installing -- i.e, "beta" version -- uncomment gavo's release and beta repos
-RUN [ "$INSTALL_REPO" = "gavo/beta" -o "$INSTALL_REPO" = "latest" -o "$INSTALL_REPO" = "gavo" ] \
-    && sed -i '/deb.*heidelberg/s/^#//' $_APT_SOURCES \
-    || echo "NOT using gavo beta/release repos"
+# 3. Environment Fixes
+ENV LC_ALL=C.UTF-8
+RUN echo LC_ALL="$LC_ALL" > /etc/default/locale
+RUN sed -i 's/exit 101/exit 0/' /usr/sbin/policy-rc.d
 
-RUN echo "Using the following repositories:" && grep "deb" $_APT_SOURCES
-
+# 4. Install Postgres and VO Extensions
 ENV PG_VERSION=${PG_VERSION}
+RUN DEBIAN_FRONTEND='noninteractive' \
+    && apt-get update \
+    && apt-get install -y \
+    postgresql-$PG_VERSION \
+    postgresql-$PG_VERSION-pgsphere \
+    postgresql-$PG_VERSION-q3c \
+    && apt-get clean
 
-RUN DEBIAN_FRONTEND='noninteractive'                                && \
-    apt-get update                                                  && \
-    apt-get install -y postgresql-$PG_VERSION                       && \
-    apt-get install -y postgresql-$PG_VERSION-pgsphere              && \
-    apt-get install -y postgresql-$PG_VERSION-q3c                   && \
-    apt-get clean
+# 5. Network Configuration (Allow Swarm Overlay Network)
+RUN PGFILE=/etc/postgresql/${PG_VERSION}/main/pg_hba.conf \
+    && echo 'host  all  all  0.0.0.0/0  trust' >> $PGFILE \
+    && echo "listen_addresses='*'" >> "${PGFILE%/*}/postgresql.conf"
 
-RUN PGFILE=/etc/postgresql/${PG_VERSION}/main/pg_hba.conf           && \
-    echo 'host  all  all  172.17.0.0/24  trust' >> $PGFILE          && \
-    echo "listen_addresses='*'" >> "${PGFILE%/*}/postgresql.conf"
+# 6. Database Initialization with Robust Wait Loop
+RUN mkdir -p -m 777 /var/run/postgresql/${PG_VERSION}-main.pg_stat_tmp/ && \
+    chown postgres:postgres /var/run/postgresql/${PG_VERSION}-main.pg_stat_tmp/ && \
+    # Start Postgres in background
+    su - postgres -c "/usr/lib/postgresql/${PG_VERSION}/bin/postgres \
+    -D /var/lib/postgresql/${PG_VERSION}/main \
+    -c config_file=/etc/postgresql/${PG_VERSION}/main/postgresql.conf" & \
+    # THE ALTERNATIVE TO SLEEP: Wait until pg_isready returns 0 (ready)
+    until su postgres -c "pg_isready"; do \
+      echo "Waiting for Postgres to start..."; \
+      sleep 1; \
+    done && \
+    # Run setup commands
+    su postgres -c "createuser -s dachsroot" && \
+    su postgres -c "createuser -s root" && \
+    su postgres -c "createdb gavo" && \
+    # Shutdown gracefully to finalize the layer
+    su postgres -c "/usr/lib/postgresql/${PG_VERSION}/bin/pg_ctl -D /var/lib/postgresql/${PG_VERSION}/main stop"
 
-RUN PGDATA=/var/lib/postgresql/${PG_VERSION}                            \
-    mkdir -p -m 777 /var/run/postgresql/${PG_VERSION}-main.pg_stat_tmp/ && \
-    su - postgres  -c "/usr/lib/postgresql/${PG_VERSION}/bin/postgres   \
-    -c config_file=/etc/postgresql/${PG_VERSION}/main/postgresql.conf \
-    -c logging_collector=on"                                          & \
-    sleep 5                                                             && \
-    su postgres -c "createuser -s dachsroot"                            && \
-    su postgres -c "createuser -s root"                                 && \
-    su postgres -c "createdb gavo"
-
-# Expose Postgres port
 EXPOSE 5432
-
-COPY bin/dachs_postgres.sh /serve.sh
-
+COPY ${DOCKER_BIN}/dachs_postgres.sh /serve.sh
 ENTRYPOINT ["/bin/bash"]
 CMD ["--rcfile", "/serve.sh"]

--- a/dockerfiles/dachs/Dockerfile.dachs_server
+++ b/dockerfiles/dachs/Dockerfile.dachs_server
@@ -1,99 +1,74 @@
 ARG BASE_IMAGE="debian:stable"
-
-# BUILD argument for extra repositories (besides debian/stable) to install dachs.
-# Options are:
-# - "gavo/beta" (gavo/release + gavo/beta)
-# - "backports" (debian/backports)
-# - "main" (debian/main)
-# * Default is "main"
+ARG PG_VERSION="17"
 ARG INSTALL_REPO="main"
-
-# PostgreSQL version to install
-# * Default is "15"
-ARG PG_VERSION="15"
+ARG CONFIG_DIR="configs"
+ARG DOCKER_BIN="bin"
+ARG GAVO_DATA="data"
 
 FROM $BASE_IMAGE
 
-LABEL Description=DaCHS\ is\ a\ publishing\ infrastructure\ for\ the\ Virtual\ Observatory. \
+ARG PG_VERSION
+ARG INSTALL_REPO
+ARG CONFIG_DIR
+ARG DOCKER_BIN
+ARG GAVO_DATA
+
+LABEL Description=DaCHS\ Server\ for\ compose.\ DaCHS\ is\ a\ publishing\ infrastructure\ for\ the\ Virtual\ Observatory. \
     Reference=http://arxiv.org/abs/1408.5733
 
-# Everyday tools
+# 1. Install Tools
 RUN DEBIAN_FRONTEND='noninteractive' \
     && apt-get update \
     && apt-get install -y \
-    curl \
-    git \
-    gnupg2 \
-    locales \
-    procps \
-    sudo \
-    vim \
-    wget \
+    curl git gnupg2 locales procps sudo vim wget \
     && apt-get clean
 
+# 2. Setup GAVO Repo
 ENV _APT_SOURCES="/etc/apt/sources.list.d/gavo.list"
-COPY etc/apt_sources.list "$_APT_SOURCES"
+COPY ${DOCKER_BIN}/apt_sources.list "$_APT_SOURCES"
 
-# Some fixes on the environment
-# ---
-# This is the brute-force solution for Debian;
-# I am having problems in set locales non-interactively,
-# and since I really need the "C/UTF8" for postgres, will just set it for all.
-ENV LC_ALL=C.UTF-8
-RUN echo LC_ALL="$LC_ALL" > /etc/default/locale
-
-RUN sed -i 's/exit 101/exit 0/' /usr/sbin/policy-rc.d
-# ---
-
-# Setup GAVO key, then repositories according to INSTALL_REPO
-# RUN wget -qO - http://docs.g-vo.org/archive-key.asc | apt-key add -
-RUN curl https://vo.ari.uni-heidelberg.de/debian/gavo-archive-keyring.asc \
+RUN curl -s https://vo.ari.uni-heidelberg.de/debian/gavo-archive-keyring.asc \
     | tee /etc/apt/trusted.gpg.d/gavo-archive.keyring.asc
 
-# If installing any version other than "main", backports is in there:
 RUN [ "$INSTALL_REPO" != "main" ] \
     && sed -i '/deb.*backports/s/^#//' $_APT_SOURCES \
-    || echo "NOT using debian/backports repo"
+    || echo "Using main repo"
 
-# If installing -- i.e, "beta" version -- uncomment gavo's release and beta repos
-RUN [ "$INSTALL_REPO" = "gavo/beta" -o "$INSTALL_REPO" = "latest" -o "$INSTALL_REPO" = "gavo" ] \
-    && sed -i '/deb.*heidelberg/s/^#//' $_APT_SOURCES \
-    || echo "NOT using gavo beta/release repos"
-
-RUN echo "Using the following repositories:" && grep "deb" $_APT_SOURCES
-
-# Define some important env
+# 3. Environment and DaCHS Vars
+ENV LC_ALL=C.UTF-8
 ENV GAVO_ROOT="/var/gavo"
 ENV GAVO_INPUTS="${GAVO_ROOT}/inputs"
 ENV GAVO_SETTINGS="/etc/gavo.rc"
 ENV GAVOSETTINGS="$GAVO_SETTINGS"
-
 ENV PG_VERSION=${PG_VERSION}
 
-# Install only the core of gavo and spatial extension to db
-RUN DEBIAN_FRONTEND='noninteractive'                  && \
-    apt-get update                                    && \
-    apt-get install -y python3-gavo                   && \
-    apt-get install -y postgresql-$PG_VERSION-q3c     && \
+# 4. Install DaCHS and Client-side Extensions
+RUN DEBIAN_FRONTEND='noninteractive' && \
+    apt-get update && \
+    apt-get install -y python3-gavo postgresql-$PG_VERSION-q3c && \
     apt-get clean
 
-# Setup dachs environment
-RUN addgroup --system gavo                                          && \
-    adduser --system --ingroup gavo gavo                            && \
+# 5. User Permissions
+RUN addgroup --system gavo && \
+    adduser --system --ingroup gavo gavo && \
     adduser --disabled-password --gecos "" --ingroup gavo dachsroot && \
-    adduser --quiet gavo gavo                                       && \
-    adduser --quiet dachsroot gavo                                  && \
-    mkdir -m 775 "${GAVO_ROOT}"                                     && \
+    adduser --quiet gavo gavo && \
+    adduser --quiet dachsroot gavo && \
+    mkdir -p -m 775 "${GAVO_ROOT}" && \
     chown dachsroot "${GAVO_ROOT}"
 
-# Copy gavo settings
-COPY etc/gavo.rc "$GAVO_SETTINGS"
+# 6. Config and Launch
+COPY ${DOCKER_BIN}/gavo.rc "$GAVO_SETTINGS"
+COPY ${CONFIG_DIR}/gavo.r[c] "$GAVO_SETTINGS"
+COPY ${CONFIG_DIR}/defaultmeta.tx[t] ${GAVO_ROOT}/etc/
+COPY ${CONFIG_DIR}/userconfig.r[d] ${GAVO_ROOT}/etc/
 
-# Add a 'port' variable to env
+# Adding a directory to store data locally
+RUN mkdir ${GAVO_DATA}
+
 ENV GAVO_PORT=8080
 EXPOSE $GAVO_PORT
 
-COPY bin/dachs_server.sh /serve.sh
-
+COPY ${DOCKER_BIN}/dachs_server.sh /serve.sh
 ENTRYPOINT ["/bin/bash"]
 CMD ["--rcfile", "/serve.sh"]

--- a/dockerfiles/dachs/README.md
+++ b/dockerfiles/dachs/README.md
@@ -10,7 +10,6 @@ $ docker run -it --name some-dachs -p 8080:8080 dachs
 This will create a container with the latest stable version of Dachs,
 as available in Debian 'main' repository.
 
-
 ## Debian/GAVO repositories
 _Par défaut_, _dachs_ will be installed from debian-stable (main) repository.
 If you feel like -- or _need_ -- to install some upgrade or patch

--- a/dockerfiles/dachs/bin_composed/apt_sources.list
+++ b/dockerfiles/dachs/bin_composed/apt_sources.list
@@ -1,0 +1,11 @@
+# The following repos extend the (lts) Dachs debian/main distribution:
+# + (Debian) Backports provides upgrades, quote:
+#     "which you don't want if you don't look at your service, but which
+#      you do want if, say, you'd like a few new fancy UDFs or so." -- Markus;
+# + (GAVO) Release and Beta: you get the bleeding edge.
+# Debian backports repo
+#deb http://deb.debian.org/debian bookworm-backports main contrib
+# GAVO release repo
+#deb http://vo.ari.uni-heidelberg.de/debian release main
+# GAVO beta repo
+#deb http://vo.ari.uni-heidelberg.de/debian beta main

--- a/dockerfiles/dachs/bin_composed/dachs_postgres.sh
+++ b/dockerfiles/dachs/bin_composed/dachs_postgres.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+echo ''
+echo '==================================================='
+echo 'This is the PostgreSQL counterpart of DaCHS server.'
+echo 'Unless you want to put your hands on the databse,'
+echo 'you should be good to go and deal with the DaCHS'
+echo 'server main conatiner itself.'
+echo ''
+echo 'To make use of this guy here, just make sure to'
+echo 'run "dachs:server" with docker "--link" option'
+echo 'pointing to this container here.'
+echo '==================================================='
+echo ''
+
+PG_VERSION=${PG_VERSION:-17}
+
+export PGDATA=/var/lib/postgresql/${PG_VERSION}
+# postgres needs this directory for log files; then start postgres
+mkdir -p -m 777 /var/run/postgresql/${PG_VERSION}-main.pg_stat_tmp/
+su - postgres  -c "/usr/lib/postgresql/${PG_VERSION}/bin/postgres \
+	-c config_file=/etc/postgresql/${PG_VERSION}/main/postgresql.conf \
+	-c logging_collector=on"

--- a/dockerfiles/dachs/bin_composed/dachs_server.sh
+++ b/dockerfiles/dachs/bin_composed/dachs_server.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+echo ''
+echo '================================================'
+echo 'This is the DaCHS server container,'
+echo 'where DaCHS daemon runs.'
+echo ''
+echo 'This container expects to use another container'
+echo 'as the PostgreSQL database server.'
+echo 'This "expectation" is satisfied with Docker'
+echo 'option --link <name-of-postgres-container>.'
+echo ''
+echo 'If something doesnt work as expected, issue-us:'
+echo '- https://github.com/chbrandt/docker-dachs'
+echo '================================================'
+echo ''
+
+# We want to now discover the name of the Postgres container to connect.
+# To do that we have to sniff the environment variables, when containers
+# link/compose environment variables are created the name of the linked
+# container.
+# Now, hard linked according to the docker compose
+# The setup is described at https://dachs-doc.readthedocs.io/tutorial.html#two-server-operation
+
+PG_HOST="${PG_NAME:-postgres}"
+
+echo "Postgres Host (container name) is: $PG_HOST"
+
+echo "Database name is gavo."
+
+chown -R dachsroot:gavo ${GAVO_ROOT}
+
+su dachsroot -c "gavo init -d 'host=${PG_HOST} dbname=gavo'"
+
+dachs serve start
+

--- a/dockerfiles/dachs/bin_composed/gavo.rc
+++ b/dockerfiles/dachs/bin_composed/gavo.rc
@@ -1,0 +1,6 @@
+[web]
+sitename: Dachs-on-Docker
+bindAddress:
+serverPort: 8080
+serverURL: http://localhost:8080
+logFormat: combined

--- a/dockerfiles/docker-compose.full.yml
+++ b/dockerfiles/docker-compose.full.yml
@@ -1,34 +1,46 @@
-version: '3'
-
 services:
-
   postgres:
     build:
-      context: ./dachs
+      context: .
+      dockerfile: dachs/Dockerfile.dachs_postgres
       args:
-        PG_VERSION: "${PG_VERSION}"
-    image: dachs:postgres
-    container_name: postgres
+        PG_VERSION: ${PG_VERSION}
+        BASE_IMAGE: ${BASE_IMAGE}
+        INSTALL_REPO: ${INSTALL_REPO}
+        DOCKER_BIN: ${DOCKER_BIN}
+    container_name: ${PG_NAME}
     tty: true
-    network_mode: 'bridge'
-
+    networks:
+      - dachs-net
+    volumes:
+      - pgdata:/var/lib/postgresql/${PG_NAME}
 
   dachs:
     build:
-      context: ./dachs
-      dockerfile: Dockerfile.dachs_server
+      context: .
+      dockerfile: dachs/Dockerfile.dachs_server
       args:
-        INSTALL_REPO: "${INSTALL_REPO}"
-        PG_VERSION: "${PG_VERSION}"
-    image: dachs:server
-    container_name: dachs
+        PG_VERSION: ${PG_VERSION}
+        BASE_IMAGE: ${BASE_IMAGE}
+        INSTALL_REPO: ${INSTALL_REPO}
+        CONFIG_DIR: ${CONFIG_DIR}
+        DOCKER_BIN: ${DOCKER_BIN}
+        GAVO_DATA: ${GAVO_DATA}
     tty: true
-    network_mode: 'bridge'
-    depends_on:
-      - postgres
-    links:
-      - postgres
+    container_name: ${DACHS_NAME}
     ports:
-      - 8080:8080
+      - "${SERVER_PORT}:8080"
+    environment:
+      - GAVO_DB_HOST=${PG_NAME}
+    networks:
+      - dachs-net
     volumes:
-      - "${DACHS_LOGS_PATH:-./tmp/logs}:/var/gavo/logs"
+      - dachs_logs:/var/gavo
+
+networks:
+  dachs-net:
+    driver: bridge
+
+volumes:
+  pgdata:
+  dachs_logs:

--- a/dockerfiles/setenv.sh
+++ b/dockerfiles/setenv.sh
@@ -1,0 +1,35 @@
+### LOCAL FOLDERS and file locations
+
+# your configuration files for DaCHS configuration (including gavo.rc etc.)
+# for build relativ to Dockerfiles
+CONFIG_DIR=dachs/bin_composed
+
+# Scripts to be copied to containers on build relative to Dockerfiles
+DOCKER_BIN=dachs/bin_composed
+
+### DaCHS Target Directories
+GAVO_ROOT=/var/gavo
+GAVO_INPUTS=${GAVO_ROOT}/inputs
+GAVO_DATA=${GAVO_ROOT}/data
+
+### DOCKER IMAGE SETTINGS
+
+# Base image of debian
+BASE_IMAGE="debian:stable" 
+
+# BUILD argument for extra repositories (besides debian/stable) to install dachs.
+# Options are:
+# - "gavo/beta" (gavo/release + gavo/beta)
+# - "backports" (debian/backports)
+# - "main" (debian/main)
+# * Default is "main"
+INSTALL_REPO=main
+
+# make sure to use the postgres version available in the package registry of the base image
+# matches the version used here
+PG_VERSION=17
+
+# names of the postgres and dachs docker container and endpoint of the DaCHS server
+PG_NAME=postgres
+DACHS_NAME=dachs
+SERVER_PORT=8080


### PR DESCRIPTION
Here an offer of some modifications of the setup we use now in KM3NeT to build the separate postgres and server containers. As the latest debian is already at postgres version 17 and we need a setup that can be easily deployed and transferred to a Docker swarm, the main changes are:

- adding a setenv.sh that also includes local folder configurations and that is propagated to the docker-compose.full.yml and the Dockerfiles
- Reducing the additional files in dockerfiles/dachs/bin_compose to the ones needed at container build
- adding a simple Makefile to generate the .env-file from the environment setting and doing the build and up/down of the container through make, providing the right environment variables.

An extended version of this is used at the [KM3NeT VO server](https://git.km3net.de/open-data/voserver) project, where the Makefile is also used for further setup tasks.

The changes should only touch the separate postgres/server setup, but I have not checked the other versions to verify.